### PR TITLE
Use compression for ssh tunnel

### DIFF
--- a/joyride/src/remote_repl.cljs
+++ b/joyride/src/remote_repl.cljs
@@ -11,7 +11,7 @@
                                                     :name label
                                                     :message (str label " Remote REPL...")})]
     (.show terminal)
-    (.sendText terminal (str "ssh -N"
+    (.sendText terminal (str "ssh -C -N"
                              " -L " nrepl-port ":localhost:" nrepl-port
                              " -L " portal-port ":localhost:" portal-port
                              " -R " extension-port ":localhost:" extension-port


### PR DESCRIPTION
None of the data served by the portal http server is compressed since it typically assumes localhost. This might help for some of the larger payloads.